### PR TITLE
Fix Rounding of Content

### DIFF
--- a/KraftBin.user.css
+++ b/KraftBin.user.css
@@ -154,7 +154,7 @@ url-prefix("https://fedia.io") {
 	}
 
 	code,
-	div {
+	div :not(.content) {
 		border-radius: var(--kraftbinBorderRadius) !important;
 	}
 


### PR DESCRIPTION
Fixes the rounding of text inside divs in the content class.

At roundness >16px, it is noticeable that divs containing text round it.